### PR TITLE
Make spacebook heading stand out

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -97,6 +97,9 @@ body{
 .section{padding:88px 0}
 .section--tinted{background: linear-gradient(180deg, transparent, var(--tint)), var(--bg-2)}
 .section__title{font-family:'Space Grotesk', system-ui; font-size:clamp(24px, 3vw, 36px); margin:0 0 16px}
+/* Emphasize Spacebook heading */
+#spacebook-title{font-size:clamp(28px, 4vw, 44px); background:linear-gradient(135deg, var(--brand-2), #a1d4ff); -webkit-background-clip:text; background-clip:text; color:transparent; text-shadow:0 0 18px rgba(71,176,255,.28)}
+#spacebook-title::after{content:''; display:block; width:88px; height:3px; margin:10px auto 0; background:linear-gradient(90deg, var(--brand-2), var(--accent)); border-radius:2px; box-shadow:0 0 18px rgba(71,176,255,.35)}
 .grid-2{display:grid; grid-template-columns: 1.2fr 1fr; gap:28px; align-items:start}
 
 /* Anchor offset fixing overlap */


### PR DESCRIPTION
Add styling to the Spacebook heading to make it stand out more.

---
<a href="https://cursor.com/background-agent?bcId=bc-e417ae81-1cba-42d9-a64a-46a7904a9d91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e417ae81-1cba-42d9-a64a-46a7904a9d91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds gradient text and decorative underline styles for `#spacebook-title` to make the Spacebook heading stand out.
> 
> - **UI/CSS**
>   - **Spacebook title styling**: New `#spacebook-title` rules add gradient text, background-clip, glow, and an `::after` gradient underline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bb9011e296c67bfa3c69670a17b52d58bc670d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->